### PR TITLE
Use lighter dependencies

### DIFF
--- a/lib/css-symbol.js
+++ b/lib/css-symbol.js
@@ -1,5 +1,5 @@
 'use strict';
 
-var Symbol = require('es6-symbol');
+var Symbol = require('es-symbol');
 
 module.exports = Symbol('css');

--- a/lib/hash.js
+++ b/lib/hash.js
@@ -1,17 +1,8 @@
 'use strict';
 
-var hashObj = require('object-hash');
-var baseX = require('base-x');
-
-var BASE62 = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
-var MAX_HASH_LENGTH = 5;
-
-var encoder = baseX(BASE62).encode;
-
-function hash(obj) {
-  return encoder(hashObj(obj, {algorithm: 'md5', encoding: 'buffer'}));
-}
+var base62 = require('base62');
+var stringHash = require('string-hash');
 
 module.exports = function hashSuffix(obj) {
-  return '_' + hash(obj).substr(0, MAX_HASH_LENGTH);
+  return '_' + base62.encode(stringHash(JSON.stringify(obj)));
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,13 @@
   "name": "scope-styles",
   "version": "0.2.0",
   "description": "converts inline style objects into scoped css",
-  "keywords": ["css", "scope", "styles", "inline", "radium"],
+  "keywords": [
+    "css",
+    "scope",
+    "styles",
+    "inline",
+    "radium"
+  ],
   "author": "Ryan Tsao <ryan.j.tsao@gmail.com>",
   "repository": "git@github.com:rtsao/scope-styles.git",
   "homepage": "https://github.com/rtsao/scope-styles",
@@ -14,9 +20,9 @@
     "travis-test": "npm run cover && ((cat coverage/lcov.info | coveralls) || exit 0)"
   },
   "dependencies": {
-    "base-x": "^1.0.1",
-    "es6-symbol": "^3.0.1",
-    "object-hash": "^0.9.1"
+    "base62": "^1.1.0",
+    "es-symbol": "^1.1.2",
+    "string-hash": "^1.1.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.4",

--- a/test/basic.expected.css
+++ b/test/basic.expected.css
@@ -1,18 +1,18 @@
-.foo_4gn20 {
+.foo_2yRvVh {
   font-weight: bold
 }
-.bar_4gn20 {
+.bar_2yRvVh {
   color: blue;
   font-size: 15px;
   background-color: #fff;
   transition: width 500ms ease
 }
-.bar_4gn20:after {
+.bar_2yRvVh:after {
   color: green;
   content: ''
 }
 @media (max-width: 600px) {
-.bar_4gn20 {
+.bar_2yRvVh {
   color: orange
 }
 }

--- a/test/basic.expected.json
+++ b/test/basic.expected.json
@@ -1,4 +1,4 @@
 {
-  "foo": "foo_4gn20",
-  "bar": "bar_4gn20"
+  "foo": "foo_2yRvVh",
+  "bar": "bar_2yRvVh"
 }

--- a/test/nest-inside-media.expected.css
+++ b/test/nest-inside-media.expected.css
@@ -1,5 +1,5 @@
 @media (max-width: 600px) {
-.foo_7phEO:after {
+.foo_lkEWA:after {
   color: blue
 }
 }

--- a/test/nest-inside-media.expected.json
+++ b/test/nest-inside-media.expected.json
@@ -1,3 +1,3 @@
 {
-  "foo": "foo_7phEO"
+  "foo": "foo_lkEWA"
 }


### PR DESCRIPTION
- Non-cryptographic hashing
- Lighter ES6 symbol polyfill
- Standard base62 encoder due to removed need for Buffer support
