### PR TITLE
  Make dot notation is part of prefix, so we can omit dot with a custom prefix.

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function scopeStyles(config, obj) {
     obj = config;
     config = {};
   }
-  config = extend({hash: hashSuffix(obj), prefix: ''}, config);
+  config = extend({hash: hashSuffix(obj), prefix: '.'}, config);
   config.hash = config.hash ? config.hash : '';
   var result = {};
   result[cssKey] = '';
@@ -78,7 +78,7 @@ function stringify(name, props, query) {
 }
 
 function makeClass(name, props) {
-  return name.prefix + '.' + name.selector + ' {\n'
+  return name.prefix + name.selector + ' {\n'
     + inlineStyle(props) + '\n}';
 }
 


### PR DESCRIPTION
Make dot notation is part of prefix, so we can omit dot with a custom prefix.
